### PR TITLE
fix usage of context-var in snippet

### DIFF
--- a/ckanext/showcase/templates/showcase/read.html
+++ b/ckanext/showcase/templates/showcase/read.html
@@ -93,7 +93,7 @@
   {% block secondary_help_content %}{% endblock %}
 
   {% block package_info %}
-    {% snippet 'showcase/snippets/showcase_info.html', pkg=pkg %}
+    {% snippet 'showcase/snippets/showcase_info.html', pkg=pkg, showcase_pkgs=c.showcase_pkgs %}
   {% endblock %}
 
   {% block package_social %}

--- a/ckanext/showcase/templates/showcase/snippets/showcase_info.html
+++ b/ckanext/showcase/templates/showcase/snippets/showcase_info.html
@@ -35,9 +35,9 @@ Example:
 
     <section class="module module-narrow">
       <h3 class="module-heading"><i class="icon-medium icon-sitemap"></i> {{ _('Datasets in Showcase') }}</h2>
-      {% if c.showcase_pkgs %}
+      {% if showcase_pkgs %}
         <ul class="nav nav-simple">
-        {% for package in c.showcase_pkgs %}
+        {% for package in showcase_pkgs %}
           {% set truncate_title = truncate_title or 80 %}
           {% set title = package.title or package.name %}
           <li class="nav-item">{{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='package', action='read', id=package.name)) }}</li>


### PR DESCRIPTION
The C-Var can not be used in a snippet. Therefore the attribute showcase_pkgs is included in the call of the snippet to provide the information of c.showcase_pkgs.

Otherwise an error occurs when trying to display the showcase-information-page.
